### PR TITLE
[Tutorial 5] MVVMを学ぶ

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'building/building_layout_screen.dart';
 import 'animation/animation_screen.dart';
@@ -8,7 +9,11 @@ import 'mercari/mercari_screen.dart';
 import 'qiita/qiita_client_screen.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(
+    const ProviderScope(
+      child: MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'animation/animation_screen.dart';
 import 'youtube/youtube_screen.dart';
 import 'residence/residence_screen.dart';
 import 'mercari/mercari_screen.dart';
+import 'qiita/qiita_client_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -59,6 +60,10 @@ class MyHomePage extends StatelessWidget {
             TransitionScreenButton(
               'Mercari',
               MercariScreen(),
+            ),
+            TransitionScreenButton(
+              'Qiita',
+              QiitaClientScreen(),
             ),
           ],
         ),

--- a/lib/qiita/api/qiita_api_client.dart
+++ b/lib/qiita/api/qiita_api_client.dart
@@ -1,0 +1,21 @@
+import 'package:dio/dio.dart';
+import 'package:pretty_dio_logger/pretty_dio_logger.dart';
+import 'package:retrofit/retrofit.dart';
+
+import 'package:flutter_tutorial/qiita/model/qiita_item.dart';
+
+part 'qiita_api_client.g.dart';
+
+@RestApi(baseUrl: "https://qiita.com/api/v2/")
+abstract class QiitaApiClient {
+  factory QiitaApiClient(Dio dio, {String baseUrl}) = _QiitaApiClient;
+
+  static QiitaApiClient create() {
+    final dio = Dio();
+    dio.interceptors.add(PrettyDioLogger());
+    return QiitaApiClient(dio);
+  }
+
+  @GET("/tags/{tag}/items")
+  Future<List<QiitaItem>> fetchQiitaItems(@Path("tag") String tag);
+}

--- a/lib/qiita/api/qiita_api_client.g.dart
+++ b/lib/qiita/api/qiita_api_client.g.dart
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'qiita_api_client.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers
+
+class _QiitaApiClient implements QiitaApiClient {
+  _QiitaApiClient(
+    this._dio, {
+    this.baseUrl,
+  }) {
+    baseUrl ??= 'https://qiita.com/api/v2/';
+  }
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  @override
+  Future<List<QiitaItem>> fetchQiitaItems(tag) async {
+    const _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    final _data = <String, dynamic>{};
+    final _result =
+        await _dio.fetch<List<dynamic>>(_setStreamType<List<QiitaItem>>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/tags/${tag}/items',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(baseUrl: baseUrl ?? _dio.options.baseUrl)));
+    var value = _result.data!
+        .map((dynamic i) => QiitaItem.fromJson(i as Map<String, dynamic>))
+        .toList();
+    return value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+}

--- a/lib/qiita/model/qiita_item.dart
+++ b/lib/qiita/model/qiita_item.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'qiita_user.dart';
+
+part 'qiita_item.freezed.dart';
+part 'qiita_item.g.dart';
+
+@freezed
+class QiitaItem with _$QiitaItem {
+  const factory QiitaItem({
+    @JsonKey(name: "title") String? title,
+    @JsonKey(name: "url") String? url,
+    @JsonKey(name: "user") QiitaUser? user,
+  }) = _QiitaItem;
+
+  factory QiitaItem.fromJson(Map<String, dynamic> json) =>
+      _$QiitaItemFromJson(json);
+}

--- a/lib/qiita/model/qiita_item.dart
+++ b/lib/qiita/model/qiita_item.dart
@@ -8,9 +8,9 @@ part 'qiita_item.g.dart';
 @freezed
 class QiitaItem with _$QiitaItem {
   const factory QiitaItem({
-    @JsonKey(name: "title") String? title,
-    @JsonKey(name: "url") String? url,
-    @JsonKey(name: "user") QiitaUser? user,
+    String? title,
+    String? url,
+    QiitaUser? user,
   }) = _QiitaItem;
 
   factory QiitaItem.fromJson(Map<String, dynamic> json) =>

--- a/lib/qiita/model/qiita_item.freezed.dart
+++ b/lib/qiita/model/qiita_item.freezed.dart
@@ -1,0 +1,236 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'qiita_item.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+QiitaItem _$QiitaItemFromJson(Map<String, dynamic> json) {
+  return _QiitaItem.fromJson(json);
+}
+
+/// @nodoc
+class _$QiitaItemTearOff {
+  const _$QiitaItemTearOff();
+
+  _QiitaItem call(
+      {@JsonKey(name: "title") String? title,
+      @JsonKey(name: "url") String? url,
+      @JsonKey(name: "user") QiitaUser? user}) {
+    return _QiitaItem(
+      title: title,
+      url: url,
+      user: user,
+    );
+  }
+
+  QiitaItem fromJson(Map<String, Object?> json) {
+    return QiitaItem.fromJson(json);
+  }
+}
+
+/// @nodoc
+const $QiitaItem = _$QiitaItemTearOff();
+
+/// @nodoc
+mixin _$QiitaItem {
+  @JsonKey(name: "title")
+  String? get title => throw _privateConstructorUsedError;
+  @JsonKey(name: "url")
+  String? get url => throw _privateConstructorUsedError;
+  @JsonKey(name: "user")
+  QiitaUser? get user => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $QiitaItemCopyWith<QiitaItem> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $QiitaItemCopyWith<$Res> {
+  factory $QiitaItemCopyWith(QiitaItem value, $Res Function(QiitaItem) then) =
+      _$QiitaItemCopyWithImpl<$Res>;
+  $Res call(
+      {@JsonKey(name: "title") String? title,
+      @JsonKey(name: "url") String? url,
+      @JsonKey(name: "user") QiitaUser? user});
+
+  $QiitaUserCopyWith<$Res>? get user;
+}
+
+/// @nodoc
+class _$QiitaItemCopyWithImpl<$Res> implements $QiitaItemCopyWith<$Res> {
+  _$QiitaItemCopyWithImpl(this._value, this._then);
+
+  final QiitaItem _value;
+  // ignore: unused_field
+  final $Res Function(QiitaItem) _then;
+
+  @override
+  $Res call({
+    Object? title = freezed,
+    Object? url = freezed,
+    Object? user = freezed,
+  }) {
+    return _then(_value.copyWith(
+      title: title == freezed
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      url: url == freezed
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String?,
+      user: user == freezed
+          ? _value.user
+          : user // ignore: cast_nullable_to_non_nullable
+              as QiitaUser?,
+    ));
+  }
+
+  @override
+  $QiitaUserCopyWith<$Res>? get user {
+    if (_value.user == null) {
+      return null;
+    }
+
+    return $QiitaUserCopyWith<$Res>(_value.user!, (value) {
+      return _then(_value.copyWith(user: value));
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$QiitaItemCopyWith<$Res> implements $QiitaItemCopyWith<$Res> {
+  factory _$QiitaItemCopyWith(
+          _QiitaItem value, $Res Function(_QiitaItem) then) =
+      __$QiitaItemCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {@JsonKey(name: "title") String? title,
+      @JsonKey(name: "url") String? url,
+      @JsonKey(name: "user") QiitaUser? user});
+
+  @override
+  $QiitaUserCopyWith<$Res>? get user;
+}
+
+/// @nodoc
+class __$QiitaItemCopyWithImpl<$Res> extends _$QiitaItemCopyWithImpl<$Res>
+    implements _$QiitaItemCopyWith<$Res> {
+  __$QiitaItemCopyWithImpl(_QiitaItem _value, $Res Function(_QiitaItem) _then)
+      : super(_value, (v) => _then(v as _QiitaItem));
+
+  @override
+  _QiitaItem get _value => super._value as _QiitaItem;
+
+  @override
+  $Res call({
+    Object? title = freezed,
+    Object? url = freezed,
+    Object? user = freezed,
+  }) {
+    return _then(_QiitaItem(
+      title: title == freezed
+          ? _value.title
+          : title // ignore: cast_nullable_to_non_nullable
+              as String?,
+      url: url == freezed
+          ? _value.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String?,
+      user: user == freezed
+          ? _value.user
+          : user // ignore: cast_nullable_to_non_nullable
+              as QiitaUser?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_QiitaItem implements _QiitaItem {
+  const _$_QiitaItem(
+      {@JsonKey(name: "title") this.title,
+      @JsonKey(name: "url") this.url,
+      @JsonKey(name: "user") this.user});
+
+  factory _$_QiitaItem.fromJson(Map<String, dynamic> json) =>
+      _$$_QiitaItemFromJson(json);
+
+  @override
+  @JsonKey(name: "title")
+  final String? title;
+  @override
+  @JsonKey(name: "url")
+  final String? url;
+  @override
+  @JsonKey(name: "user")
+  final QiitaUser? user;
+
+  @override
+  String toString() {
+    return 'QiitaItem(title: $title, url: $url, user: $user)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _QiitaItem &&
+            const DeepCollectionEquality().equals(other.title, title) &&
+            const DeepCollectionEquality().equals(other.url, url) &&
+            const DeepCollectionEquality().equals(other.user, user));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(title),
+      const DeepCollectionEquality().hash(url),
+      const DeepCollectionEquality().hash(user));
+
+  @JsonKey(ignore: true)
+  @override
+  _$QiitaItemCopyWith<_QiitaItem> get copyWith =>
+      __$QiitaItemCopyWithImpl<_QiitaItem>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_QiitaItemToJson(this);
+  }
+}
+
+abstract class _QiitaItem implements QiitaItem {
+  const factory _QiitaItem(
+      {@JsonKey(name: "title") String? title,
+      @JsonKey(name: "url") String? url,
+      @JsonKey(name: "user") QiitaUser? user}) = _$_QiitaItem;
+
+  factory _QiitaItem.fromJson(Map<String, dynamic> json) =
+      _$_QiitaItem.fromJson;
+
+  @override
+  @JsonKey(name: "title")
+  String? get title;
+  @override
+  @JsonKey(name: "url")
+  String? get url;
+  @override
+  @JsonKey(name: "user")
+  QiitaUser? get user;
+  @override
+  @JsonKey(ignore: true)
+  _$QiitaItemCopyWith<_QiitaItem> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/qiita/model/qiita_item.freezed.dart
+++ b/lib/qiita/model/qiita_item.freezed.dart
@@ -22,10 +22,7 @@ QiitaItem _$QiitaItemFromJson(Map<String, dynamic> json) {
 class _$QiitaItemTearOff {
   const _$QiitaItemTearOff();
 
-  _QiitaItem call(
-      {@JsonKey(name: "title") String? title,
-      @JsonKey(name: "url") String? url,
-      @JsonKey(name: "user") QiitaUser? user}) {
+  _QiitaItem call({String? title, String? url, QiitaUser? user}) {
     return _QiitaItem(
       title: title,
       url: url,
@@ -43,11 +40,8 @@ const $QiitaItem = _$QiitaItemTearOff();
 
 /// @nodoc
 mixin _$QiitaItem {
-  @JsonKey(name: "title")
   String? get title => throw _privateConstructorUsedError;
-  @JsonKey(name: "url")
   String? get url => throw _privateConstructorUsedError;
-  @JsonKey(name: "user")
   QiitaUser? get user => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -60,10 +54,7 @@ mixin _$QiitaItem {
 abstract class $QiitaItemCopyWith<$Res> {
   factory $QiitaItemCopyWith(QiitaItem value, $Res Function(QiitaItem) then) =
       _$QiitaItemCopyWithImpl<$Res>;
-  $Res call(
-      {@JsonKey(name: "title") String? title,
-      @JsonKey(name: "url") String? url,
-      @JsonKey(name: "user") QiitaUser? user});
+  $Res call({String? title, String? url, QiitaUser? user});
 
   $QiitaUserCopyWith<$Res>? get user;
 }
@@ -116,10 +107,7 @@ abstract class _$QiitaItemCopyWith<$Res> implements $QiitaItemCopyWith<$Res> {
           _QiitaItem value, $Res Function(_QiitaItem) then) =
       __$QiitaItemCopyWithImpl<$Res>;
   @override
-  $Res call(
-      {@JsonKey(name: "title") String? title,
-      @JsonKey(name: "url") String? url,
-      @JsonKey(name: "user") QiitaUser? user});
+  $Res call({String? title, String? url, QiitaUser? user});
 
   @override
   $QiitaUserCopyWith<$Res>? get user;
@@ -160,22 +148,16 @@ class __$QiitaItemCopyWithImpl<$Res> extends _$QiitaItemCopyWithImpl<$Res>
 /// @nodoc
 @JsonSerializable()
 class _$_QiitaItem implements _QiitaItem {
-  const _$_QiitaItem(
-      {@JsonKey(name: "title") this.title,
-      @JsonKey(name: "url") this.url,
-      @JsonKey(name: "user") this.user});
+  const _$_QiitaItem({this.title, this.url, this.user});
 
   factory _$_QiitaItem.fromJson(Map<String, dynamic> json) =>
       _$$_QiitaItemFromJson(json);
 
   @override
-  @JsonKey(name: "title")
   final String? title;
   @override
-  @JsonKey(name: "url")
   final String? url;
   @override
-  @JsonKey(name: "user")
   final QiitaUser? user;
 
   @override
@@ -212,22 +194,17 @@ class _$_QiitaItem implements _QiitaItem {
 }
 
 abstract class _QiitaItem implements QiitaItem {
-  const factory _QiitaItem(
-      {@JsonKey(name: "title") String? title,
-      @JsonKey(name: "url") String? url,
-      @JsonKey(name: "user") QiitaUser? user}) = _$_QiitaItem;
+  const factory _QiitaItem({String? title, String? url, QiitaUser? user}) =
+      _$_QiitaItem;
 
   factory _QiitaItem.fromJson(Map<String, dynamic> json) =
       _$_QiitaItem.fromJson;
 
   @override
-  @JsonKey(name: "title")
   String? get title;
   @override
-  @JsonKey(name: "url")
   String? get url;
   @override
-  @JsonKey(name: "user")
   QiitaUser? get user;
   @override
   @JsonKey(ignore: true)

--- a/lib/qiita/model/qiita_item.g.dart
+++ b/lib/qiita/model/qiita_item.g.dart
@@ -1,0 +1,22 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'qiita_item.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_QiitaItem _$$_QiitaItemFromJson(Map<String, dynamic> json) => _$_QiitaItem(
+      title: json['title'] as String?,
+      url: json['url'] as String?,
+      user: json['user'] == null
+          ? null
+          : QiitaUser.fromJson(json['user'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$_QiitaItemToJson(_$_QiitaItem instance) =>
+    <String, dynamic>{
+      'title': instance.title,
+      'url': instance.url,
+      'user': instance.user,
+    };

--- a/lib/qiita/model/qiita_user.dart
+++ b/lib/qiita/model/qiita_user.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'qiita_user.freezed.dart';
+part 'qiita_user.g.dart';
+
+@freezed
+class QiitaUser with _$QiitaUser {
+  const factory QiitaUser({
+    @JsonKey(name: "profile_image_url") String? profileImageUrl,
+  }) = _QiitaUser;
+
+  factory QiitaUser.fromJson(Map<String, dynamic> json) =>
+      _$QiitaUserFromJson(json);
+}

--- a/lib/qiita/model/qiita_user.freezed.dart
+++ b/lib/qiita/model/qiita_user.freezed.dart
@@ -1,0 +1,167 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'qiita_user.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+QiitaUser _$QiitaUserFromJson(Map<String, dynamic> json) {
+  return _QiitaUser.fromJson(json);
+}
+
+/// @nodoc
+class _$QiitaUserTearOff {
+  const _$QiitaUserTearOff();
+
+  _QiitaUser call(
+      {@JsonKey(name: "profile_image_url") String? profileImageUrl}) {
+    return _QiitaUser(
+      profileImageUrl: profileImageUrl,
+    );
+  }
+
+  QiitaUser fromJson(Map<String, Object?> json) {
+    return QiitaUser.fromJson(json);
+  }
+}
+
+/// @nodoc
+const $QiitaUser = _$QiitaUserTearOff();
+
+/// @nodoc
+mixin _$QiitaUser {
+  @JsonKey(name: "profile_image_url")
+  String? get profileImageUrl => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $QiitaUserCopyWith<QiitaUser> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $QiitaUserCopyWith<$Res> {
+  factory $QiitaUserCopyWith(QiitaUser value, $Res Function(QiitaUser) then) =
+      _$QiitaUserCopyWithImpl<$Res>;
+  $Res call({@JsonKey(name: "profile_image_url") String? profileImageUrl});
+}
+
+/// @nodoc
+class _$QiitaUserCopyWithImpl<$Res> implements $QiitaUserCopyWith<$Res> {
+  _$QiitaUserCopyWithImpl(this._value, this._then);
+
+  final QiitaUser _value;
+  // ignore: unused_field
+  final $Res Function(QiitaUser) _then;
+
+  @override
+  $Res call({
+    Object? profileImageUrl = freezed,
+  }) {
+    return _then(_value.copyWith(
+      profileImageUrl: profileImageUrl == freezed
+          ? _value.profileImageUrl
+          : profileImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$QiitaUserCopyWith<$Res> implements $QiitaUserCopyWith<$Res> {
+  factory _$QiitaUserCopyWith(
+          _QiitaUser value, $Res Function(_QiitaUser) then) =
+      __$QiitaUserCopyWithImpl<$Res>;
+  @override
+  $Res call({@JsonKey(name: "profile_image_url") String? profileImageUrl});
+}
+
+/// @nodoc
+class __$QiitaUserCopyWithImpl<$Res> extends _$QiitaUserCopyWithImpl<$Res>
+    implements _$QiitaUserCopyWith<$Res> {
+  __$QiitaUserCopyWithImpl(_QiitaUser _value, $Res Function(_QiitaUser) _then)
+      : super(_value, (v) => _then(v as _QiitaUser));
+
+  @override
+  _QiitaUser get _value => super._value as _QiitaUser;
+
+  @override
+  $Res call({
+    Object? profileImageUrl = freezed,
+  }) {
+    return _then(_QiitaUser(
+      profileImageUrl: profileImageUrl == freezed
+          ? _value.profileImageUrl
+          : profileImageUrl // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_QiitaUser implements _QiitaUser {
+  const _$_QiitaUser(
+      {@JsonKey(name: "profile_image_url") this.profileImageUrl});
+
+  factory _$_QiitaUser.fromJson(Map<String, dynamic> json) =>
+      _$$_QiitaUserFromJson(json);
+
+  @override
+  @JsonKey(name: "profile_image_url")
+  final String? profileImageUrl;
+
+  @override
+  String toString() {
+    return 'QiitaUser(profileImageUrl: $profileImageUrl)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _QiitaUser &&
+            const DeepCollectionEquality()
+                .equals(other.profileImageUrl, profileImageUrl));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(profileImageUrl));
+
+  @JsonKey(ignore: true)
+  @override
+  _$QiitaUserCopyWith<_QiitaUser> get copyWith =>
+      __$QiitaUserCopyWithImpl<_QiitaUser>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_QiitaUserToJson(this);
+  }
+}
+
+abstract class _QiitaUser implements QiitaUser {
+  const factory _QiitaUser(
+          {@JsonKey(name: "profile_image_url") String? profileImageUrl}) =
+      _$_QiitaUser;
+
+  factory _QiitaUser.fromJson(Map<String, dynamic> json) =
+      _$_QiitaUser.fromJson;
+
+  @override
+  @JsonKey(name: "profile_image_url")
+  String? get profileImageUrl;
+  @override
+  @JsonKey(ignore: true)
+  _$QiitaUserCopyWith<_QiitaUser> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/qiita/model/qiita_user.g.dart
+++ b/lib/qiita/model/qiita_user.g.dart
@@ -1,0 +1,16 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'qiita_user.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_QiitaUser _$$_QiitaUserFromJson(Map<String, dynamic> json) => _$_QiitaUser(
+      profileImageUrl: json['profile_image_url'] as String?,
+    );
+
+Map<String, dynamic> _$$_QiitaUserToJson(_$_QiitaUser instance) =>
+    <String, dynamic>{
+      'profile_image_url': instance.profileImageUrl,
+    };

--- a/lib/qiita/qiita_client_screen.dart
+++ b/lib/qiita/qiita_client_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class QiitaClientScreen extends StatelessWidget {
+  const QiitaClientScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}

--- a/lib/qiita/qiita_client_screen.dart
+++ b/lib/qiita/qiita_client_screen.dart
@@ -10,9 +10,8 @@ class QiitaClientScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(qiitaClientStateNotifier);
 
-    return
-        // 戻るボタンの挙動
-        WillPopScope(
+    return WillPopScope(
+      // 戻るボタンの挙動
       onWillPop: state.isReadyData
           ? () {
               ref.read(qiitaClientStateNotifier.notifier).onBackHome();
@@ -35,7 +34,7 @@ class QiitaClientScreen extends ConsumerWidget {
             ),
             Visibility(
               visible: state.isLoading,
-              child: Container(
+              child: ColoredBox(
                 color: Color(0x88000000),
                 child: Center(
                   child: CircularProgressIndicator(),
@@ -56,7 +55,7 @@ class QiitaClientScreen extends ConsumerWidget {
         final item = qiitaItems[index];
 
         return Container(
-          padding: EdgeInsets.only(top: 4, bottom: 4, left: 8, right: 8),
+          padding: EdgeInsets.symmetric(vertical: 4, horizontal: 8),
           constraints: BoxConstraints(minHeight: 96, maxHeight: 96),
           child: Card(
             elevation: 8,

--- a/lib/qiita/qiita_client_screen.dart
+++ b/lib/qiita/qiita_client_screen.dart
@@ -1,10 +1,103 @@
 import 'package:flutter/material.dart';
 
-class QiitaClientScreen extends StatelessWidget {
-  const QiitaClientScreen({Key? key}) : super(key: key);
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'model/qiita_item.dart';
+import 'qiita_client_state_notifier.dart';
+
+class QiitaClientScreen extends ConsumerWidget {
   @override
-  Widget build(BuildContext context) {
-    return Container();
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(qiitaClientStateNotifier);
+
+    return
+        // 戻るボタンの挙動
+        WillPopScope(
+      onWillPop: state.isReadyData
+          ? () {
+              ref.read(qiitaClientStateNotifier.notifier).onBackHome();
+              return Future.value(false);
+            }
+          : null,
+      child: Scaffold(
+        appBar: AppBar(
+          title: state.isReadyData
+              ? Text(state.currentTag)
+              : Text('QiitaClientSample'),
+          centerTitle: true,
+        ),
+        body: Stack(
+          children: [
+            Center(
+              child: state.isReadyData
+                  ? _createListView(state.qiitaItems)
+                  : _createSearchButtons(ref),
+            ),
+            Visibility(
+              visible: state.isLoading,
+              child: Container(
+                color: Color(0x88000000),
+                child: Center(
+                  child: CircularProgressIndicator(),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // タグのボタンを押してデータが取得されたら表示されるリスト
+  Widget _createListView(List<QiitaItem> qiitaItems) {
+    return ListView.builder(
+      itemCount: qiitaItems.length,
+      itemBuilder: (context, index) {
+        final item = qiitaItems[index];
+
+        return Container(
+          padding: EdgeInsets.only(top: 4, bottom: 4, left: 8, right: 8),
+          constraints: BoxConstraints(minHeight: 96, maxHeight: 96),
+          child: Card(
+            elevation: 8,
+            child: Container(
+              alignment: Alignment.centerLeft,
+              padding: EdgeInsets.all(16),
+              child: ListTile(
+                leading: Image.network(item.user!.profileImageUrl!),
+                title: Text(item.title!),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  // データ未取得時に表示するタグのボタン
+  Widget _createSearchButtons(WidgetRef ref) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        ElevatedButton(
+          onPressed: () => ref
+              .read(qiitaClientStateNotifier.notifier)
+              .fetchQiitaItems('Flutter'),
+          child: Text('Flutter'),
+        ),
+        ElevatedButton(
+          onPressed: () => ref
+              .read(qiitaClientStateNotifier.notifier)
+              .fetchQiitaItems('android'),
+          child: Text('android'),
+        ),
+        ElevatedButton(
+          onPressed: () => ref
+              .read(qiitaClientStateNotifier.notifier)
+              .fetchQiitaItems('ios'),
+          child: Text('ios'),
+        ),
+      ],
+    );
   }
 }

--- a/lib/qiita/qiita_client_state_notifier.dart
+++ b/lib/qiita/qiita_client_state_notifier.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'repository/qiita_repository.dart';
+import 'state/qiita_client_state.dart';
+
+final qiitaClientStateNotifier = StateNotifierProvider.autoDispose<
+    QiitaClientStateNotifier,
+    QiitaClientState>((ref) => QiitaClientStateNotifier(ref.read));
+
+class QiitaClientStateNotifier extends StateNotifier<QiitaClientState> {
+  QiitaClientStateNotifier(this._read) : super(QiitaClientState());
+
+  final Reader _read;
+
+  Future<void> fetchQiitaItems(String tag) async {
+    state = state.copyWith(isLoading: true);
+
+    final qiitaItems =
+        await _read(qiitaRepositoryProvider).fetchQiitaItems(tag);
+
+    if (qiitaItems.length != 0) {
+      state = state.copyWith(
+          isLoading: false,
+          isReadyData: true,
+          currentTag: tag,
+          qiitaItems: qiitaItems);
+    } else {
+      state = state.copyWith(
+        isLoading: false,
+        isReadyData: false,
+        qiitaItems: qiitaItems,
+      );
+    }
+  }
+
+  onBackHome() {
+    state = state.copyWith(
+      isLoading: false,
+      isReadyData: false,
+      currentTag: "",
+    );
+  }
+}

--- a/lib/qiita/qiita_client_state_notifier.dart
+++ b/lib/qiita/qiita_client_state_notifier.dart
@@ -18,7 +18,7 @@ class QiitaClientStateNotifier extends StateNotifier<QiitaClientState> {
     final qiitaItems =
         await _read(qiitaRepositoryProvider).fetchQiitaItems(tag);
 
-    if (qiitaItems.length != 0) {
+    if (qiitaItems.isNotEmpty) {
       state = state.copyWith(
           isLoading: false,
           isReadyData: true,

--- a/lib/qiita/repository/qiita_repository.dart
+++ b/lib/qiita/repository/qiita_repository.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:flutter_tutorial/qiita/api/qiita_api_client.dart';
+import 'package:flutter_tutorial/qiita/model/qiita_item.dart';
+
+final qiitaRepositoryProvider =
+    Provider<QiitaRepository>((_) => QiitaRepository());
+
+class QiitaRepository {
+  QiitaApiClient _api = QiitaApiClient.create();
+
+  Future<List<QiitaItem>> fetchQiitaItems(String tag) async {
+    return _api.fetchQiitaItems(tag);
+  }
+}

--- a/lib/qiita/state/qiita_client_state.dart
+++ b/lib/qiita/state/qiita_client_state.dart
@@ -1,0 +1,15 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'package:flutter_tutorial/qiita/model/qiita_item.dart';
+
+part 'qiita_client_state.freezed.dart';
+
+@freezed
+class QiitaClientState with _$QiitaClientState {
+  const factory QiitaClientState({
+    @Default(false) bool isLoading,
+    @Default(false) bool isReadyData,
+    @Default(<QiitaItem>[]) List<QiitaItem> qiitaItems,
+    @Default('') String currentTag,
+  }) = _QiitaClientState;
+}

--- a/lib/qiita/state/qiita_client_state.freezed.dart
+++ b/lib/qiita/state/qiita_client_state.freezed.dart
@@ -1,0 +1,226 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'qiita_client_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more informations: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+/// @nodoc
+class _$QiitaClientStateTearOff {
+  const _$QiitaClientStateTearOff();
+
+  _QiitaClientState call(
+      {bool isLoading = false,
+      bool isReadyData = false,
+      List<QiitaItem> qiitaItems = const <QiitaItem>[],
+      String currentTag = ''}) {
+    return _QiitaClientState(
+      isLoading: isLoading,
+      isReadyData: isReadyData,
+      qiitaItems: qiitaItems,
+      currentTag: currentTag,
+    );
+  }
+}
+
+/// @nodoc
+const $QiitaClientState = _$QiitaClientStateTearOff();
+
+/// @nodoc
+mixin _$QiitaClientState {
+  bool get isLoading => throw _privateConstructorUsedError;
+  bool get isReadyData => throw _privateConstructorUsedError;
+  List<QiitaItem> get qiitaItems => throw _privateConstructorUsedError;
+  String get currentTag => throw _privateConstructorUsedError;
+
+  @JsonKey(ignore: true)
+  $QiitaClientStateCopyWith<QiitaClientState> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $QiitaClientStateCopyWith<$Res> {
+  factory $QiitaClientStateCopyWith(
+          QiitaClientState value, $Res Function(QiitaClientState) then) =
+      _$QiitaClientStateCopyWithImpl<$Res>;
+  $Res call(
+      {bool isLoading,
+      bool isReadyData,
+      List<QiitaItem> qiitaItems,
+      String currentTag});
+}
+
+/// @nodoc
+class _$QiitaClientStateCopyWithImpl<$Res>
+    implements $QiitaClientStateCopyWith<$Res> {
+  _$QiitaClientStateCopyWithImpl(this._value, this._then);
+
+  final QiitaClientState _value;
+  // ignore: unused_field
+  final $Res Function(QiitaClientState) _then;
+
+  @override
+  $Res call({
+    Object? isLoading = freezed,
+    Object? isReadyData = freezed,
+    Object? qiitaItems = freezed,
+    Object? currentTag = freezed,
+  }) {
+    return _then(_value.copyWith(
+      isLoading: isLoading == freezed
+          ? _value.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isReadyData: isReadyData == freezed
+          ? _value.isReadyData
+          : isReadyData // ignore: cast_nullable_to_non_nullable
+              as bool,
+      qiitaItems: qiitaItems == freezed
+          ? _value.qiitaItems
+          : qiitaItems // ignore: cast_nullable_to_non_nullable
+              as List<QiitaItem>,
+      currentTag: currentTag == freezed
+          ? _value.currentTag
+          : currentTag // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$QiitaClientStateCopyWith<$Res>
+    implements $QiitaClientStateCopyWith<$Res> {
+  factory _$QiitaClientStateCopyWith(
+          _QiitaClientState value, $Res Function(_QiitaClientState) then) =
+      __$QiitaClientStateCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {bool isLoading,
+      bool isReadyData,
+      List<QiitaItem> qiitaItems,
+      String currentTag});
+}
+
+/// @nodoc
+class __$QiitaClientStateCopyWithImpl<$Res>
+    extends _$QiitaClientStateCopyWithImpl<$Res>
+    implements _$QiitaClientStateCopyWith<$Res> {
+  __$QiitaClientStateCopyWithImpl(
+      _QiitaClientState _value, $Res Function(_QiitaClientState) _then)
+      : super(_value, (v) => _then(v as _QiitaClientState));
+
+  @override
+  _QiitaClientState get _value => super._value as _QiitaClientState;
+
+  @override
+  $Res call({
+    Object? isLoading = freezed,
+    Object? isReadyData = freezed,
+    Object? qiitaItems = freezed,
+    Object? currentTag = freezed,
+  }) {
+    return _then(_QiitaClientState(
+      isLoading: isLoading == freezed
+          ? _value.isLoading
+          : isLoading // ignore: cast_nullable_to_non_nullable
+              as bool,
+      isReadyData: isReadyData == freezed
+          ? _value.isReadyData
+          : isReadyData // ignore: cast_nullable_to_non_nullable
+              as bool,
+      qiitaItems: qiitaItems == freezed
+          ? _value.qiitaItems
+          : qiitaItems // ignore: cast_nullable_to_non_nullable
+              as List<QiitaItem>,
+      currentTag: currentTag == freezed
+          ? _value.currentTag
+          : currentTag // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$_QiitaClientState implements _QiitaClientState {
+  const _$_QiitaClientState(
+      {this.isLoading = false,
+      this.isReadyData = false,
+      this.qiitaItems = const <QiitaItem>[],
+      this.currentTag = ''});
+
+  @JsonKey()
+  @override
+  final bool isLoading;
+  @JsonKey()
+  @override
+  final bool isReadyData;
+  @JsonKey()
+  @override
+  final List<QiitaItem> qiitaItems;
+  @JsonKey()
+  @override
+  final String currentTag;
+
+  @override
+  String toString() {
+    return 'QiitaClientState(isLoading: $isLoading, isReadyData: $isReadyData, qiitaItems: $qiitaItems, currentTag: $currentTag)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _QiitaClientState &&
+            const DeepCollectionEquality().equals(other.isLoading, isLoading) &&
+            const DeepCollectionEquality()
+                .equals(other.isReadyData, isReadyData) &&
+            const DeepCollectionEquality()
+                .equals(other.qiitaItems, qiitaItems) &&
+            const DeepCollectionEquality()
+                .equals(other.currentTag, currentTag));
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(isLoading),
+      const DeepCollectionEquality().hash(isReadyData),
+      const DeepCollectionEquality().hash(qiitaItems),
+      const DeepCollectionEquality().hash(currentTag));
+
+  @JsonKey(ignore: true)
+  @override
+  _$QiitaClientStateCopyWith<_QiitaClientState> get copyWith =>
+      __$QiitaClientStateCopyWithImpl<_QiitaClientState>(this, _$identity);
+}
+
+abstract class _QiitaClientState implements QiitaClientState {
+  const factory _QiitaClientState(
+      {bool isLoading,
+      bool isReadyData,
+      List<QiitaItem> qiitaItems,
+      String currentTag}) = _$_QiitaClientState;
+
+  @override
+  bool get isLoading;
+  @override
+  bool get isReadyData;
+  @override
+  List<QiitaItem> get qiitaItems;
+  @override
+  String get currentTag;
+  @override
+  @JsonKey(ignore: true)
+  _$QiitaClientStateCopyWith<_QiitaClientState> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,12 @@ dependencies:
   cupertino_icons: ^1.0.2
   flutter_svg: ^1.1.5
   badges: ^2.0.3
+  freezed_annotation: ^1.1.0
+  retrofit: ^3.0.1
+  logging: ^1.0.2
+  pretty_dio_logger: ^1.1.1
+  flutter_riverpod: ^1.0.3
+  flutter_state_notifier: ^0.7.1
 
 dev_dependencies:
   flutter_test:
@@ -47,6 +53,10 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^2.0.0
+  build_runner: ^2.1.7
+  freezed: ^1.1.1
+  retrofit_generator: ^4.0.1
+  json_serializable: ^6.1.4
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
### 課題
 - Tutorial 5
 - MVVMアーキテクチャに触れて、手元に動くソースを作る
 - 各パッケージの導入
   - freezed
   - json_serializable
   - riverpod
   - retrofit

---

### 主な実装内容
Tutorial 5のNotionに記載されている参考リポジトリと同じ内容です。
（パブリックリポジトリのため、NotionやリポジトリのURLの記載は省略させていただきます🙇🏻‍♂️）

-  lib/main.dart
   - ProviderScopeの追加
   - qiita_client_screen.dartへの遷移ボタンを追加

 - lib/qiita/ 
    - api/
    - model/
    - repository/
    - state/
    - qiita_client_screen.dart
    - qiita_client_state_notifier.dart

 - pubspec.yaml
    - パッケージの追加

---
### 動作サンプル
https://user-images.githubusercontent.com/114896398/196843161-dcbb716c-8d0d-4be8-bf19-9cc7959dfe0a.mov

---

### 課題（悩んだこと）
特にありません。

---

### 備考
いつもレビューありがとうございます。
レビューよろしくお願いします！